### PR TITLE
fix register_user call in _init_default_user

### DIFF
--- a/plynx/web/common.py
+++ b/plynx/web/common.py
@@ -108,7 +108,7 @@ def register_user(username, password, email):
 def _init_default_user():
 
     if not UserCollectionManager.find_user_by_name(DEFAULT_USERNAME):
-        message = register_user(DEFAULT_EMAIL, DEFAULT_USERNAME, DEFAULT_PASSWORD)
+        message = register_user(DEFAULT_USERNAME, DEFAULT_PASSWORD, DEFAULT_EMAIL)
         if message:
             raise Exception(message)
         logging.info('Created default user `{}`'.format(DEFAULT_USERNAME))


### PR DESCRIPTION
Fix error created by wrong method call on first startup in single user mode.

Stacktrace:
api         | INFO:root:Single user mode
api         |   File "/usr/local/bin/plynx", line 33, in <module>
api         |   File "/usr/local/lib/python3.7/site-packages/plynx-1.5.0-py3.7.egg/plynx/bin/__init__.py", line 13, in main
api         |     args.func(kwargs)
api         |   File "/usr/local/lib/python3.7/site-packages/plynx-1.5.0-py3.7.egg/plynx/bin/cli.py", line 26, in api
api         |     run_api(**args)
api         |   File "/usr/local/lib/python3.7/site-packages/plynx-1.5.0-py3.7.egg/plynx/web/common.py", line 160, in run_api
api         |     _init_default_user()
api         |   File "/usr/local/lib/python3.7/site-packages/plynx-1.5.0-py3.7.egg/plynx/web/common.py", line 111, in _init_default_user
api         |     message = register_user(DEFAULT_EMAIL, DEFAULT_USERNAME, DEFAULT_PASSWORD)
api         |   File "/usr/local/lib/python3.7/site-packages/plynx-1.5.0-py3.7.egg/plynx/web/common.py", line 72, in register_user
api         |     error_code=RegisterUserExceptionCode.EMPTY_USERNAME
api         | plynx.utils.exceptions.RegisterUserException: Missing username